### PR TITLE
Updated ECS name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Gryphon Cluster Viewer
 ======================
 
-AWS EC2 Container Service Interface
+Amazon EC2 Container Service Interface
 
 <img src="/mascot.png?raw=true" width="500">
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Gryphon Cluster Viewer
 ======================
 
-AWS Elastic Container Service Interface
+AWS EC2 Container Service Interface
 
 <img src="/mascot.png?raw=true" width="500">
 


### PR DESCRIPTION
ECS is EC2 Container Service rather than Elastic Container Service
Corrected README.md