### PR TITLE
Change task definition rendering

### DIFF
--- a/gryphon/templates/definitions.html
+++ b/gryphon/templates/definitions.html
@@ -65,7 +65,7 @@
                     {% include "consolebutton.html" %}
                     {% set container_def = task_def.container_defs[0] %}
                     {% include "runbutton.html" %}
-                    {{family.name}} - {{task_def.revision}}
+                    {{family.name}}:{{task_def.revision}}
                 </div>
             {% endfor %}
         </div>

--- a/gryphon/templates/task.html
+++ b/gryphon/templates/task.html
@@ -4,7 +4,7 @@
         pending
     </div>
     {% endif %}
-    {{task.definition.family.name}} - {{task.definition.revision}}
+    {{task.definition.family.name}}:{{task.definition.revision}}
     <a class='action' target='_blank' href="https://console.aws.amazon.com/ecs/home?region=us-east-1#/clusters/{{cluster.name}}/tasks/{{task.arn[-36:]}}">console</a>
 
     <ul class='container-list'>


### PR DESCRIPTION
Task [definition] names now use the same format as used in ECS service settings:

`task-name:revision`

This makes copying and pasting easier when changing/creating services.